### PR TITLE
add server.destroy for v3 tests

### DIFF
--- a/tests/versioned/aws-sdk-v3/sns.tap.js
+++ b/tests/versioned/aws-sdk-v3/sns.tap.js
@@ -47,7 +47,7 @@ tap.test('SNS', (t) => {
   })
 
   t.afterEach(() => {
-    server.close()
+    server.destroy()
     server = null
 
     helper && helper.unload()

--- a/tests/versioned/aws-sdk-v3/sqs.tap.js
+++ b/tests/versioned/aws-sdk-v3/sqs.tap.js
@@ -66,7 +66,7 @@ tap.test('SQS API', (t) => {
   t.afterEach(() => {
     helper && helper.unload()
 
-    server.close()
+    server.destroy()
     server = null
 
     helper = null

--- a/tests/versioned/aws-server-stubs/response-server/index.js
+++ b/tests/versioned/aws-server-stubs/response-server/index.js
@@ -37,7 +37,6 @@ function createResponseServer() {
   })
   server.destroy = function () {
     sockets.forEach((socket) => {
-      sockets.delete(socket)
       socket.destroy()
     })
     server.close()

--- a/tests/versioned/aws-server-stubs/response-server/index.js
+++ b/tests/versioned/aws-server-stubs/response-server/index.js
@@ -26,6 +26,21 @@ function createResponseServer() {
     res.end()
   })
 
+  // make close faster
+  const sockets = new Set()
+  server.on('connection', (socket) => {
+    sockets.add(socket)
+    socket.once('close', () => {
+      sockets.delete(socket)
+    })
+  })
+  server.destroy = function () {
+    sockets.forEach((socket) => {
+      socket.destroy()
+    })
+    server.close()
+  }
+
   return server
 }
 

--- a/tests/versioned/aws-server-stubs/response-server/index.js
+++ b/tests/versioned/aws-server-stubs/response-server/index.js
@@ -26,7 +26,8 @@ function createResponseServer() {
     res.end()
   })
 
-  // make close faster
+  // server.destroy: close, but faster!
+  // tracks and manually closes any open sockets
   const sockets = new Set()
   server.on('connection', (socket) => {
     sockets.add(socket)
@@ -36,6 +37,7 @@ function createResponseServer() {
   })
   server.destroy = function () {
     sockets.forEach((socket) => {
+      sockets.delete(socket)
       socket.destroy()
     })
     server.close()


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

- https://stackoverflow.com/questions/14626636/how-do-i-shutdown-a-node-js-https-server-immediately
- https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/node-reusing-connections.html

## Details

As v3 [reuses connections](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/node-reusing-connections.html), using `server.close` to close the test server causes tests to hang while waiting on these connections to close. This PR implements `server.destroy` which manually destroys any open connections, allowing tests to clean up quickly.
